### PR TITLE
FEATURE: Include Debounce capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,39 +51,94 @@ for more information.
 
 In order to define custom [sidekiq_options](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) you can add `sidekiq_options` class method in your subscriber definition - those options will be passed to Sidekiq's `set` method just before scheduling the asynchronous worker.
 
-### Passing down schedule options
-
-In order be able to schedule jobs to be run in the future following [Scheduled Jobs](https://github.com/mperham/sidekiq/wiki/Scheduled-Jobs) you can add `sidekiq_schedule_options` class method in your subscriber definition - those options will be passed to Sidekiq's `perform_in` method when the worker is called.
+In order be able to schedule jobs to be run in the future following [Scheduled Jobs](https://github.com/mperham/sidekiq/wiki/Scheduled-Jobs) you can add `sidekiq_options` class method in your subscriber definition - those options will be passed to Sidekiq's `perform_in` method when the worker is called.
 
 This feature is not as powerfull as Sidekiq's API that allows you to set this on every job enqueue, in this case you're able to set this for the hole listener class like:
 ```ruby
 class MyListener
-  #...
-
-  def self.sidekiq_schedule_options
-    { perform_in: 5 }
+  def self.sidekiq_options
+    # If you don't wanna debounce, but instead, just schedule to run in the future, use `perform_in` option
+    { queue: 'my_custom_queue', retry: false, perform_in: 15 }
+    
+    # in_seconds: the amount of time to debounce the events
+    # expire_in_seconds: the amount of time for the key to stay present on redis cache
+    # keys: you can define an array of attributes which debounce will look for on arguments to create an unique key to identify the debouncing jobs
+    # NOTICE: If you pass a KEY that is not part of your arguments, you may cause inconsistent debouncing
+    { debounce: { in_seconds: 15, expire_in_seconds: 60*60, keys: [:user_id, :email] } }
   end
-
-  #...
 end
 ```
-Or you can set this per event (method called on the listener), like so:
+
+### Using the debounce feature
+
+This is a new feature that was implemented in order to prevent broadcasting messages to be processed multiple times
+for the same event. This is useful if, for some instance, your class is subscribed to many channels/events, and you don't
+want the job to process one time for each of the events.
+
+Under the hood Redis is used to store an unique key created based on the 
+
 ```ruby
 class MyListener
-  #...
-
-  def self.sidekiq_schedule_options
-    { event_name: { perform_in: 5 } }
+  def self.sidekiq_options
+    # in_seconds: the amount of time to debounce the events
+    # expire_in_seconds: the amount of time for the key to stay present on redis cache
+    # keys: you can define an array of attributes which debounce will look for on arguments to create an unique key to identify the debouncing jobs
+    # NOTICE 1: If you pass a KEY that is not part of your arguments, you may cause inconsistent debouncing
+    # NOTICE 2: `debounce: { in_seconds: 15 }` will IGNORE the `perform_in` argument
+    { debounce: { in_seconds: 15, expire_in_seconds: 60*60, keys: [:user_id, :email] } }
   end
-
-  def self.event_name
-    #...
-  end
-
-  #...
 end
 ```
-In both cases there is also available the `perform_at` option.
+
+The `keys` option allow you to use both named arguments or methods without named arguments.
+All you have to do is specify the number/position of the arguments.
+Let's say you have a method that receives `my_method(value1, value2)`.
+If you want to use `value2` as the debounce key, all you have to do is this:
+
+```ruby
+class MyListener
+  def self.sidekiq_options
+    # KEYS: can receive the name of the argument, or the position
+    # 1 here represents `value2`, since because arguments start with position 0
+    { debounce: { in_seconds: 15, keys: [1] } }
+  end
+
+  def perform(value1, value2)
+    # do something...
+  end
+end
+```
+
+The `overwrite_event_name` can be used to uniquely identify the whole class and it's events, no matter how many of
+them you have this class subscribed to, all of the events are gonna to have the same event name, which is used to
+compound the `debounce_key` used to identify the processed jobs and debounce them.
+
+```ruby
+class MyListener
+  def self.sidekiq_options
+    { debounce: { overwrite_event_name: 'my_custom_event' } }
+  end
+
+  def perform(value1, value2)
+    # do something...
+  end
+end
+
+# Subscribe the same class to multiple events/publishers
+# If you use `overwrite_event_name` instead of the event name be `first_publisher`, `second_publisher`,
+# `third_publisher` it will be `my_custom_event` 
+FirstPublisher.subscribe(MyListener.new)
+SecondPublisher.subscribe(MyListener.new)
+ThirdPublisher.subscribe(MyListener.new)
+```
+
+Under the hood this will call the `perform_in` method.
+
+### Limitations
+
+It's not possible to use mixed arguments.
+If you have a class with a method like this `my_method(value1, email:)` and you wanna use both arguments
+as debounce keys, what you should do is `debounce: { keys: [0, 1] }`.
 
 ## Compatibility
 

--- a/lib/wisper/sidekiq.rb
+++ b/lib/wisper/sidekiq.rb
@@ -4,60 +4,110 @@ require 'sidekiq'
 require 'wisper/sidekiq/version'
 
 module Wisper
-
   # based on Sidekiq 4.x #delay method, which is not enabled by default in Sidekiq 5.x
   # https://github.com/mperham/sidekiq/blob/4.x/lib/sidekiq/extensions/generic_proxy.rb
   # https://github.com/mperham/sidekiq/blob/4.x/lib/sidekiq/extensions/class_methods.rb
 
   class SidekiqBroadcaster
+    def self.register
+      Wisper.configure do |config|
+        config.broadcaster :sidekiq, SidekiqBroadcaster.new
+        config.broadcaster :async, SidekiqBroadcaster.new
+      end
+    end
+
     class Worker
       include ::Sidekiq::Worker
 
       def perform(yml)
-        (subscriber, event, args) = ::YAML.load(yml)
-        subscriber.public_send(event, *args)
-      end
-    end
+        (subscriber, event, args, debounce_key, debounce_id) = unpack_args(yml)
 
-    def self.register
-      Wisper.configure do |config|
-        config.broadcaster :sidekiq, SidekiqBroadcaster.new
-        config.broadcaster :async,   SidekiqBroadcaster.new
+        # In case we are unable to pass a debounce_key AND debounce_id, this means something went wrong
+        # and we should NOT prevent Wisper/Sidekiq to process the events
+        if debounce_key && debounce_id
+          ::Sidekiq.redis do |redis|
+            # Retrieve the last saved Job ID and compare with the current debounce_id running
+            last_stored_debounce_key = redis.get(debounce_key)
+            # If false, this means this event being called IS NOT the last event emitted, which means we should debounce
+            subscriber.public_send(event, *args) if last_stored_debounce_key == debounce_id
+          end
+        else
+          subscriber.public_send(event, *args)
+        end
+      end
+
+      private
+
+      def unpack_args(yml)
+        # yml can contain nil values, there are no problems on that
+        # no reason to worry about debounce_key or debounce_id to be nil sometimes
+        if Psych::VERSION.to_i >= 4
+          ::YAML.unsafe_load(yml)
+        else
+          ::YAML.load(yml)
+        end
       end
     end
 
     def broadcast(subscriber, publisher, event, args)
-      options = sidekiq_options(subscriber)
-      schedule_options = sidekiq_schedule_options(subscriber, event)
+      # options include options like queue, retry, and other sidekiq_options
+      original_options = sidekiq_options(subscriber)
+      debounce_options = original_options[:debounce]
+      # Initialize the Sidekiq::Worker object with sidekiq_options
+      worker = Worker.set(original_options)
 
-      Worker.set(options).perform_in(
-        schedule_options.fetch(:delay, 0),
-        ::YAML.dump([subscriber, event, args])
-      )
-    end
+      # 1. Do we have debounce options? Yes, then we can proceed using the debounce mechanism
+      if debounce_options
+        # Create an unique debounce_key that will be used to identify similar jobs being scheduled during the debounce period
+        debounce_key = compute_debounce_key(subscriber, event, args, debounce_options)
+        # Generate an unique JOB ID before trying to schedule the job, this way we can pass this
+        # ID down to the `perform` method to correctly identify the last scheduled job
+        debounce_id = SecureRandom.uuid
+        # By default, we expire the Redis unique identifier in 2 hours
+        debounce_expire_in_seconds = debounce_options[:expire_in_seconds] || 60*60*2
 
-    private
-
-    def sidekiq_options(subscriber)
-      subscriber.respond_to?(:sidekiq_options) ? subscriber.sidekiq_options : {}
-    end
-
-    def sidekiq_schedule_options(subscriber, event)
-      return {} unless subscriber.respond_to?(:sidekiq_schedule_options)
-
-      options = subscriber.sidekiq_schedule_options
-
-      if options.has_key?(event.to_sym)
-        delay_option(options[event.to_sym])
+        ::Sidekiq.redis do |redis|
+          save_debounce_key_on_redis(redis, debounce_key, debounce_id, debounce_expire_in_seconds)
+          schedule_sidekiq_job(worker, debounce_options[:in_seconds], subscriber, event, args, debounce_key: debounce_key, debounce_id: debounce_id)
+        end
+      # 2. If we don't then just schedule the job as normal
       else
-        delay_option(options)
+        delay_in_seconds = original_options[:perform_in] || 0
+        schedule_sidekiq_job(worker, delay_in_seconds, subscriber, event, args)
       end
     end
 
-    def delay_option(options)
-      return {} unless options.key?(:perform_in) || options.key?(:perform_at)
+    def compute_debounce_key(subscriber, event, args, debounce_options)
+      event_name = debounce_options.dig(:overwrite_event_name) || event
+      # There is no sense of calculating the key if no arguments are passed
+      return "#{subscriber}-#{event_name}-debounce" unless args[0]
 
-      { delay: options[:perform_in] || options[:perform_at] }
+      # Grab all the keys that should be used from arguments
+      debounce_keys = debounce_options.dig(:keys) || []
+      # Now grab the values of the arguments using the keys
+      # ARGS is always an Array, that's why the need of [0]
+      debounce_by_arguments = debounce_keys.map {|key| args.first[key]}
+      # Group everything into a string that will be used to compound the key
+      final_debounce_key = debounce_by_arguments.join('-')
+
+      "#{subscriber}-#{event_name}-#{final_debounce_key}"
+    end
+
+    def pack_args(subscriber, event, args, debounce_key, debounce_id)
+      # Even if debounce_key or debounce_id are nil, there are no problems dumping the YAML
+      ::YAML.dump([subscriber, event, args, debounce_key, debounce_id])
+    end
+
+    def save_debounce_key_on_redis(redis, debounce_key, debounce_id, expire_in_seconds)
+      redis.set(debounce_key, debounce_id, ex: expire_in_seconds)
+    end
+
+    def schedule_sidekiq_job(worker, debounce_in_seconds, subscriber, event, args, debounce_key: nil, debounce_id: nil)
+      worker.perform_in(debounce_in_seconds, pack_args(subscriber, event, args, debounce_key, debounce_id))
+    end
+
+    def sidekiq_options(subscriber)
+      subscriber.respond_to?(:sidekiq_options) ? subscriber.sidekiq_options : { perform_in: 0 }
     end
   end
 end

--- a/lib/wisper/sidekiq/version.rb
+++ b/lib/wisper/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Wisper
   module Sidekiq
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
   end
 end

--- a/scripts/sidekiq
+++ b/scripts/sidekiq
@@ -2,4 +2,4 @@
 
 set -e
 
-bundle exec rerun --dir spec/dummy_app/ -- bundle exec sidekiq -r ./spec/dummy_app/app.rb -L ./spec/dummy_app/logs/sidekiq.log
+bundle exec rerun --dir spec/dummy_app/ -- bundle exec sidekiq -r ./spec/dummy_app/app.rb ./spec/dummy_app/logs/sidekiq.log

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'integration tests:' do
       end
     end.new
   end
+
   let(:shared_content) { File.read('/tmp/shared') }
 
   def ensure_sidekiq_was_running

--- a/wisper-sidekiq.gemspec
+++ b/wisper-sidekiq.gemspec
@@ -6,7 +6,7 @@ require 'wisper/sidekiq/version'
 Gem::Specification.new do |spec|
   spec.name          = "wisper-sidekiq"
   spec.version       = Wisper::Sidekiq::VERSION
-  spec.authors       = ["Kris Leech"]
+  spec.authors       = ["Kris Leech", "Joe Gaudet", "Patrick Muller"]
   spec.email         = ["kris.leech@gmail.com"]
   spec.summary       = 'Async publishing for Wisper using Sidekiq'
   spec.description   = 'Async publishing for Wisper using Sidekiq'


### PR DESCRIPTION
- [x] Include new options for `sidekiq_options` like: `perform_in: 15` (in seconds), `debounce: { in_seconds: 15, keys: [:order_id], overwrite_event_name: 'my_custom_event' }` (using sidekiq-debouncer gem as inspiration)
- [x] Update README to include all necessary information on how to properly use this new feature
- [x] Update tests to properly reflect new sidekiq_options
- [x] Update tests to properly reflect debounce scenarios
- [x] Add the possibility to specify by which arguments you're gonna debounce a method
- [x] Add the possibility to specify a custom event name to use when your class is subscribed to multiple events